### PR TITLE
Use the expand method to get the file extension instead of &filetype

### DIFF
--- a/teacode.vim
+++ b/teacode.vim
@@ -2,7 +2,8 @@ function! TeaCodeExpand()
 	" Collect data
 	let trigger  = getline( '.' ) 
 	let line     = line( '.' )
-	let filetype = &filetype
+	let filetype = expand( '%:e' )
+
 	" Gets the current line and column
 	let cursor = getpos('.')
 


### PR DESCRIPTION
* Replaces the `&filetype`
* Fixes issue where TeaCode would get confused sometimes since `&filetype` would return e.g. `javascript` instead of the true file extension e.g. `js`