### PR TITLE
use json_decode

### DIFF
--- a/plugin/teacode.vim
+++ b/plugin/teacode.vim
@@ -13,7 +13,7 @@ function! TeaCodeExpand()
 	let ob = system( "sh ../expand.sh -e ". &ft ." -t '". trigger ."'" )
 
 	" Convert command response to an object by running eval function
-	let object = js_decode( ob )
+	let object = json_decode( ob )
 	let s:result = object.text
 
 	" Report install TeaCode if error.


### PR DESCRIPTION
The output of `expand.sh` is JSON:
```json
{"foundPattern":"class","text":"class() {\n    \n}","cursorPosition":14}
```
Using, `js_decode()` states that it's keys must not be quoted. 

Changed to use `json_decode()` to match what you be expected.

Addresses secondary issue in #10 